### PR TITLE
feat: TradingView webhook integration (dual-feed)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -72,6 +72,10 @@ TAKE_PROFIT_PERCENTAGE = 0.10  # 10% take profit
 SCAN_INTERVAL_SECONDS = 300  # 5 minutes
 MAX_CONCURRENT_SCANS = 3
 
+# TradingView Integration
+TRADINGVIEW_SECRET = os.environ.get("TRADINGVIEW_SECRET", "")
+TRADINGVIEW_ENABLED = os.environ.get("TRADINGVIEW_ENABLED", "true").lower() == "true"
+
 # Database Configuration  
 DATABASE_URL = f"sqlite:///{DATA_DIR / 'tradesight.db'}"
 

--- a/src/integrations/tradingview_adapter.py
+++ b/src/integrations/tradingview_adapter.py
@@ -1,0 +1,101 @@
+"""
+TradeSight TradingView Webhook Adapter
+
+Parses, validates, and converts TradingView alert webhooks
+into the internal signal format consumed by PaperTrader.execute_signal().
+"""
+
+import hmac
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+REQUIRED_FIELDS = {"symbol", "action", "confidence"}
+VALID_ACTIONS = {"buy", "sell"}
+CONFIDENCE_MIN = 0.55
+CONFIDENCE_MAX = 0.85
+
+
+@dataclass(frozen=True)
+class TradingViewSignal:
+    """Immutable parsed TradingView alert signal."""
+    symbol: str
+    action: str
+    confidence: float
+    price: Optional[float]
+    reason: str
+    strategy: str
+
+
+def parse_tradingview_payload(raw: dict) -> TradingViewSignal:
+    """Parse and validate incoming TradingView webhook payload.
+
+    Args:
+        raw: JSON payload from TradingView webhook.
+
+    Returns:
+        Validated TradingViewSignal.
+
+    Raises:
+        ValueError: If required fields are missing or action is invalid.
+    """
+    missing = REQUIRED_FIELDS - raw.keys()
+    if missing:
+        raise ValueError(f"Missing required fields: {', '.join(sorted(missing))}")
+
+    action = str(raw["action"]).lower()
+    if action not in VALID_ACTIONS:
+        raise ValueError(f"Invalid action: '{action}'. Must be one of: {', '.join(VALID_ACTIONS)}")
+
+    confidence = float(raw["confidence"])
+    confidence = max(CONFIDENCE_MIN, min(CONFIDENCE_MAX, confidence))
+
+    price_raw = raw.get("price")
+    price = float(price_raw) if price_raw is not None else None
+
+    return TradingViewSignal(
+        symbol=str(raw["symbol"]).upper(),
+        action=action,
+        confidence=confidence,
+        price=price,
+        reason=raw.get("reason", f"TradingView {action} signal"),
+        strategy=raw.get("strategy", "TradingView"),
+    )
+
+
+def verify_token(payload: dict, expected_token: str) -> bool:
+    """Verify webhook authentication token using constant-time comparison.
+
+    Args:
+        payload: Webhook JSON payload (expects a "token" key).
+        expected_token: The expected secret token.
+
+    Returns:
+        True if token matches, False otherwise.
+    """
+    token = payload.get("token")
+    if token is None:
+        return False
+    return hmac.compare_digest(str(token), expected_token)
+
+
+def to_internal_signal(tv_signal: TradingViewSignal, current_price: float) -> dict:
+    """Convert TradingViewSignal to PaperTrader internal signal format.
+
+    Args:
+        tv_signal: Parsed TradingView signal.
+        current_price: Current market price for the symbol.
+
+    Returns:
+        Dict matching PaperTrader.execute_signal() expected format.
+    """
+    return {
+        "symbol": tv_signal.symbol,
+        "action": tv_signal.action,
+        "side": "long" if tv_signal.action == "buy" else "short",
+        "confidence": tv_signal.confidence,
+        "reason": tv_signal.reason,
+        "strategy": tv_signal.strategy,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "current_price": current_price,
+    }

--- a/tests/test_tradingview.py
+++ b/tests/test_tradingview.py
@@ -1,0 +1,364 @@
+"""
+TradeSight TradingView Webhook Integration Tests
+
+Test suite for TradingView alert parsing, validation, and webhook endpoint.
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import Mock, patch
+from datetime import datetime
+import json
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+class TestTradingViewAdapter:
+    """Pure unit tests for TradingView signal parsing and validation."""
+
+    def test_parse_valid_buy_signal(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        payload = {
+            "symbol": "aapl",
+            "action": "buy",
+            "confidence": 0.70,
+            "price": 185.50,
+            "reason": "RSI oversold",
+            "strategy": "RSI_SMA"
+        }
+
+        signal = parse_tradingview_payload(payload)
+
+        assert signal.symbol == "AAPL"
+        assert signal.action == "buy"
+        assert signal.confidence == 0.70
+        assert signal.price == 185.50
+        assert signal.reason == "RSI oversold"
+        assert signal.strategy == "RSI_SMA"
+
+    def test_parse_valid_sell_signal(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        payload = {
+            "symbol": "MSFT",
+            "action": "sell",
+            "confidence": 0.75,
+            "price": 340.25,
+            "reason": "Taking profit",
+            "strategy": "Confluence"
+        }
+
+        signal = parse_tradingview_payload(payload)
+
+        assert signal.symbol == "MSFT"
+        assert signal.action == "sell"
+        assert signal.confidence == 0.75
+
+    def test_parse_missing_required_symbol(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        with pytest.raises(ValueError, match="symbol"):
+            parse_tradingview_payload({"action": "buy", "confidence": 0.70})
+
+    def test_parse_missing_required_action(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        with pytest.raises(ValueError, match="action"):
+            parse_tradingview_payload({"symbol": "AAPL", "confidence": 0.70})
+
+    def test_parse_missing_required_confidence(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        with pytest.raises(ValueError, match="confidence"):
+            parse_tradingview_payload({"symbol": "AAPL", "action": "buy"})
+
+    def test_parse_invalid_action(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        with pytest.raises(ValueError, match="action"):
+            parse_tradingview_payload({
+                "symbol": "AAPL", "action": "hold", "confidence": 0.70
+            })
+
+    def test_parse_action_case_insensitive(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        signal = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "BUY", "confidence": 0.70
+        })
+        assert signal.action == "buy"
+
+    def test_confidence_clamped_below_minimum(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        signal = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.30
+        })
+        assert signal.confidence == 0.55
+
+    def test_confidence_clamped_above_maximum(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        signal = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.95
+        })
+        assert signal.confidence == 0.85
+
+    def test_confidence_within_range_unchanged(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        signal = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.70
+        })
+        assert signal.confidence == 0.70
+
+    def test_symbol_uppercased(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        signal = parse_tradingview_payload({
+            "symbol": "aapl", "action": "buy", "confidence": 0.70
+        })
+        assert signal.symbol == "AAPL"
+
+    def test_parse_optional_price_none(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        signal = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.70
+        })
+        assert signal.price is None
+
+    def test_parse_optional_defaults(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload
+
+        signal = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.70
+        })
+        assert len(signal.reason) > 0
+        assert len(signal.strategy) > 0
+
+    def test_to_internal_signal_buy_sets_long_side(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload, to_internal_signal
+
+        tv = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.70
+        })
+        internal = to_internal_signal(tv, 185.50)
+
+        assert internal["side"] == "long"
+        assert internal["action"] == "buy"
+
+    def test_to_internal_signal_sell_sets_short_side(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload, to_internal_signal
+
+        tv = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "sell", "confidence": 0.70
+        })
+        internal = to_internal_signal(tv, 185.50)
+
+        assert internal["side"] == "short"
+        assert internal["action"] == "sell"
+
+    def test_to_internal_signal_has_required_fields(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload, to_internal_signal
+
+        tv = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.70,
+            "price": 185.50, "reason": "Test", "strategy": "TestStrat"
+        })
+        internal = to_internal_signal(tv, 185.50)
+
+        required = {"symbol", "action", "side", "confidence", "reason",
+                     "strategy", "timestamp", "current_price"}
+        assert required.issubset(internal.keys())
+        assert internal["symbol"] == "AAPL"
+        assert internal["current_price"] == 185.50
+
+    def test_to_internal_signal_timestamp_iso(self):
+        from integrations.tradingview_adapter import parse_tradingview_payload, to_internal_signal
+
+        tv = parse_tradingview_payload({
+            "symbol": "AAPL", "action": "buy", "confidence": 0.70
+        })
+        internal = to_internal_signal(tv, 185.50)
+
+        datetime.fromisoformat(internal["timestamp"].replace('Z', '+00:00'))
+
+    def test_verify_token_valid(self):
+        from integrations.tradingview_adapter import verify_token
+        assert verify_token({"token": "secret123"}, "secret123") is True
+
+    def test_verify_token_invalid(self):
+        from integrations.tradingview_adapter import verify_token
+        assert verify_token({"token": "secret123"}, "wrong") is False
+
+    def test_verify_token_missing_key(self):
+        from integrations.tradingview_adapter import verify_token
+        assert verify_token({"symbol": "AAPL"}, "secret123") is False
+
+
+class TestTradingViewWebhook:
+    """Flask integration tests for /api/tradingview/webhook endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+        # Mock talib (C library) if not installed
+        if 'talib' not in sys.modules:
+            sys.modules['talib'] = Mock()
+        from web.dashboard import app
+        self.app = app
+        self.client = app.test_client()
+        yield
+
+    def test_webhook_returns_400_invalid_json(self):
+        response = self.client.post(
+            '/api/tradingview/webhook',
+            data='not json',
+            content_type='application/json'
+        )
+        assert response.status_code == 400
+        assert json.loads(response.data)['success'] is False
+
+    def test_webhook_returns_401_wrong_token(self):
+        with patch('web.dashboard.TRADINGVIEW_SECRET', 'expected'), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True):
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"token": "wrong", "symbol": "AAPL",
+                      "action": "buy", "confidence": 0.70}
+            )
+            assert response.status_code == 401
+
+    def test_webhook_returns_422_missing_symbol(self):
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True):
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"action": "buy", "confidence": 0.70}
+            )
+            assert response.status_code == 422
+
+    @patch('web.dashboard.get_paper_trader')
+    def test_webhook_valid_buy(self, mock_get_trader):
+        mock_trader = Mock()
+        mock_trader.execute_signal.return_value = True
+        mock_get_trader.return_value = mock_trader
+
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True), \
+             patch('web.dashboard._get_live_price', return_value=185.50):
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "AAPL", "action": "buy",
+                      "confidence": 0.70, "price": 185.50}
+            )
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert data['success'] is True
+            assert data['executed'] is True
+            assert data['symbol'] == "AAPL"
+            mock_trader.execute_signal.assert_called_once()
+
+    @patch('web.dashboard.get_paper_trader')
+    def test_webhook_valid_sell(self, mock_get_trader):
+        mock_trader = Mock()
+        mock_trader.execute_signal.return_value = True
+        mock_get_trader.return_value = mock_trader
+
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True), \
+             patch('web.dashboard._get_live_price', return_value=340.25):
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "MSFT", "action": "sell",
+                      "confidence": 0.75, "price": 340.25}
+            )
+            assert response.status_code == 200
+            assert json.loads(response.data)['success'] is True
+
+    def test_webhook_returns_503_disabled(self):
+        with patch('web.dashboard.TRADINGVIEW_ENABLED', False):
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "AAPL", "action": "buy", "confidence": 0.70}
+            )
+            assert response.status_code == 503
+
+    @patch('web.dashboard.get_paper_trader')
+    def test_webhook_returns_500_execution_error(self, mock_get_trader):
+        mock_trader = Mock()
+        mock_trader.execute_signal.side_effect = RuntimeError("Connection failed")
+        mock_get_trader.return_value = mock_trader
+
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True), \
+             patch('web.dashboard._get_live_price', return_value=185.50):
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "AAPL", "action": "buy", "confidence": 0.70}
+            )
+            assert response.status_code == 500
+
+    @patch('web.dashboard.get_paper_trader')
+    def test_webhook_503_price_unavailable(self, mock_get_trader):
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True), \
+             patch('web.dashboard._get_live_price', side_effect=RuntimeError("No data")):
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "AAPL", "action": "buy", "confidence": 0.70}
+            )
+            assert response.status_code == 503
+
+    @patch('web.dashboard.get_paper_trader')
+    def test_webhook_execute_not_called_on_parse_error(self, mock_get_trader):
+        mock_trader = Mock()
+        mock_get_trader.return_value = mock_trader
+
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True):
+            self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "AAPL", "action": "invalid", "confidence": 0.70}
+            )
+            mock_trader.execute_signal.assert_not_called()
+
+    @patch('web.dashboard.get_paper_trader')
+    def test_webhook_uses_provided_price(self, mock_get_trader):
+        mock_trader = Mock()
+        mock_trader.execute_signal.return_value = True
+        mock_get_trader.return_value = mock_trader
+        mock_live = Mock()
+
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True), \
+             patch('web.dashboard._get_live_price', mock_live):
+            self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "AAPL", "action": "buy",
+                      "confidence": 0.70, "price": 185.50}
+            )
+            mock_live.assert_not_called()
+
+    @patch('web.dashboard.get_paper_trader')
+    def test_webhook_fetches_price_if_missing(self, mock_get_trader):
+        mock_trader = Mock()
+        mock_trader.execute_signal.return_value = True
+        mock_get_trader.return_value = mock_trader
+
+        with patch('web.dashboard.TRADINGVIEW_SECRET', ''), \
+             patch('web.dashboard.TRADINGVIEW_ENABLED', True), \
+             patch('web.dashboard._get_live_price', return_value=187.25) as mock_live:
+            response = self.client.post(
+                '/api/tradingview/webhook',
+                json={"symbol": "AAPL", "action": "buy", "confidence": 0.70}
+            )
+            mock_live.assert_called_once_with("AAPL")
+            assert json.loads(response.data)['price'] == 187.25
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/web/dashboard.py
+++ b/web/dashboard.py
@@ -65,6 +65,61 @@ except Exception as _e:
     _dashboard_alert_manager = None
     _DASHBOARD_ALERTS_AVAILABLE = False
 
+# TradingView Integration
+try:
+    from config import TRADINGVIEW_SECRET, TRADINGVIEW_ENABLED
+    from integrations.tradingview_adapter import (
+        parse_tradingview_payload, verify_token, to_internal_signal
+    )
+    _TRADINGVIEW_AVAILABLE = True
+except Exception as _tv_e:
+    TRADINGVIEW_SECRET = ""
+    TRADINGVIEW_ENABLED = False
+    _TRADINGVIEW_AVAILABLE = False
+
+# Lazy PaperTrader singleton for webhook execution
+_paper_trader_instance = None
+_paper_trader_lock = threading.Lock()
+
+
+def get_paper_trader():
+    """Get or create the PaperTrader singleton (thread-safe, lazy init)."""
+    global _paper_trader_instance
+    with _paper_trader_lock:
+        if _paper_trader_instance is None:
+            from trading.paper_trader import PaperTrader
+            try:
+                from utils.keychain import get_alpaca_api_key, get_alpaca_secret_key
+                api_key = get_alpaca_api_key()
+                secret_key = get_alpaca_secret_key()
+            except Exception:
+                api_key = os.environ.get("ALPACA_API_KEY", "")
+                secret_key = os.environ.get("ALPACA_SECRET_KEY", "")
+            base_dir = os.path.join(os.path.dirname(__file__), '..', 'src')
+            _paper_trader_instance = PaperTrader(
+                base_dir=base_dir,
+                alpaca_api_key=api_key,
+                alpaca_secret=secret_key
+            )
+        return _paper_trader_instance
+
+
+def _get_live_price(symbol: str) -> float:
+    """Fetch live price from Alpaca for a symbol."""
+    from data.alpaca_client import AlpacaClient
+    try:
+        from utils.keychain import get_alpaca_api_key, get_alpaca_secret_key
+        api_key = get_alpaca_api_key()
+        secret_key = get_alpaca_secret_key()
+    except Exception:
+        api_key = os.environ.get("ALPACA_API_KEY", "")
+        secret_key = os.environ.get("ALPACA_SECRET_KEY", "")
+    client = AlpacaClient(api_key=api_key, secret_key=secret_key, paper=True)
+    quote = client.get_quote(symbol)
+    if quote is None or quote.last <= 0:
+        raise RuntimeError(f"No valid price for {symbol}")
+    return quote.last
+
 app.json_encoder = NumpySafeEncoder
 
 def safe_jsonify(data):
@@ -727,6 +782,66 @@ def emergency_restore_positions():
         return jsonify({'restored': restored, 'alpaca_positions': len(alpaca_positions)})
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+# ===========================================================================
+# TradingView Webhook API (Dual-Feed Integration)
+# ===========================================================================
+
+@app.route('/api/tradingview/webhook', methods=['POST'])
+def tradingview_webhook():
+    """Receive TradingView alert webhooks and execute paper trades.
+
+    Expected JSON payload:
+        {
+            "token": "YOUR_SECRET",         (optional, validated if TRADINGVIEW_SECRET is set)
+            "symbol": "AAPL",               (required)
+            "action": "buy" | "sell",       (required)
+            "confidence": 0.70,             (required, clamped to [0.55, 0.85])
+            "price": 185.50,                (optional, fetched from Alpaca if absent)
+            "strategy": "MyStrategy",       (optional, defaults to "TradingView")
+            "reason": "RSI oversold"        (optional)
+        }
+    """
+    if not TRADINGVIEW_ENABLED:
+        return jsonify({"success": False, "error": "TradingView integration disabled"}), 503
+
+    raw = request.get_json(silent=True)
+    if not raw:
+        return jsonify({"success": False, "error": "Invalid JSON"}), 400
+
+    # Token verification (if secret configured)
+    if TRADINGVIEW_SECRET:
+        if not verify_token(raw, TRADINGVIEW_SECRET):
+            return jsonify({"success": False, "error": "Invalid token"}), 401
+
+    try:
+        tv_signal = parse_tradingview_payload(raw)
+    except ValueError as exc:
+        return jsonify({"success": False, "error": str(exc)}), 422
+
+    # Resolve price: use payload price or fetch live quote from Alpaca
+    try:
+        current_price = tv_signal.price or _get_live_price(tv_signal.symbol)
+    except Exception as exc:
+        return jsonify({"success": False, "error": f"Price unavailable: {exc}"}), 503
+
+    signal = to_internal_signal(tv_signal, current_price)
+
+    try:
+        trader = get_paper_trader()
+        executed = trader.execute_signal(signal)
+    except Exception as exc:
+        return jsonify({"success": False, "error": f"Execution error: {exc}"}), 500
+
+    return jsonify({
+        "success": True,
+        "executed": executed,
+        "symbol": tv_signal.symbol,
+        "action": tv_signal.action,
+        "confidence": tv_signal.confidence,
+        "price": current_price
+    })
+
 
 if __name__ == '__main__':
     app.run(debug=False, host="127.0.0.1", port=5001)


### PR DESCRIPTION
## Summary
- Add `POST /api/tradingview/webhook` endpoint to receive TradingView Pine Script alerts
- Parse, validate, and convert TV signals into the internal PaperTrader format
- Execute paper trades via the existing `PaperTrader.execute_signal()` pipeline
- Token-based auth, confidence clamping [0.55-0.85], live price fallback via Alpaca

## Files changed
| File | Change |
|------|--------|
| `src/integrations/tradingview_adapter.py` | **New** — parse, validate, convert TV webhooks |
| `src/integrations/__init__.py` | **New** — package init |
| `src/config.py` | **Modified** — `TRADINGVIEW_SECRET`, `TRADINGVIEW_ENABLED` env vars |
| `web/dashboard.py` | **Modified** — webhook route + lazy PaperTrader singleton + price helper |
| `tests/test_tradingview.py` | **New** — 31 tests (20 adapter unit + 11 Flask integration) |

## TradingView Alert Template
```json
{
  "token": "YOUR_SECRET",
  "symbol": "{{ticker}}",
  "action": "{{strategy.order.action}}",
  "price": {{close}},
  "confidence": 0.70,
  "strategy": "{{strategy.order.comment}}",
  "reason": "TV alert {{interval}} {{time}}"
}
```

## Test plan
- [x] 20 adapter unit tests (parsing, validation, conversion, token auth)
- [x] 11 Flask integration tests (400/401/422/500/503 error paths + happy path)
- [x] All 31 tests passing
- [ ] Manual smoke test with `curl` against running dashboard
- [ ] End-to-end test with real TradingView alert (requires TV Pro account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)